### PR TITLE
Baf/feature/add recipe to cook or display ingredients needed

### DIFF
--- a/src/css/_buttons.scss
+++ b/src/css/_buttons.scss
@@ -1,6 +1,7 @@
 .show-pantry-recipes-btn,
 .show-all-btn,
-.filter-btn {
+.filter-btn,
+.recipe-okay-button {
   background-color: $eucalyptus-green;
   border: 0;
   border-radius: 3px;
@@ -23,4 +24,8 @@
 .show-all-btn {
   @include setDimensions(40px, 200px);
   margin-top: 20px;
+}
+
+.recipe-okay-button {
+  display: none;
 }

--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -72,7 +72,7 @@ const domUpdates = {
 
       generateIngredients(recipe) {
         return recipe && recipe.ingredients.map(i => {
-          return `${this.capitalize(i.name)} (${i.quantity.amount} ${i.quantity.unit})`
+          return `${(i.name)} (${i.quantity.amount} ${i.quantity.unit})`
         }).join(", ");
       },
 
@@ -99,9 +99,21 @@ const domUpdates = {
         });
         fullRecipeInfo.insertAdjacentHTML("afterbegin", `<ol>${instructionsList}</ol>`);
         fullRecipeInfo.insertAdjacentHTML("afterbegin", "<h4>Instructions</h4>");
-      },
+       },
 
-
+       displayMissingIngredients(missingIngredients, recipeButton, fullRecipeInfo) {
+         while (fullRecipeInfo.childNodes.length > 2) {
+           fullRecipeInfo.removeChild(fullRecipeInfo.firstChild);
+         };
+         recipeButton.style.display = "none";
+         // let completeIngredientsList = missingIngredients.map(i => {
+         //   return `${this.capitalize(i.name)} (${i.quantity.amount} ${i.quantity.unit})`
+         // }).join(", ");
+         // console.log(completeIngredientsList);
+         return missingIngredients.forEach(ingredient => {
+           return fullRecipeInfo.insertAdjacentHTML("afterbegin", `<li>${ingredient.name}, ${ingredient.quantity.amount}, ${ingredient.quantity.unit}</li>`)
+         });
+       },
 
        exitRecipe(fullRecipeInfo) {
         while (fullRecipeInfo.childNodes.length > 2) {

--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -106,18 +106,20 @@ const domUpdates = {
            fullRecipeInfo.removeChild(fullRecipeInfo.firstChild);
          };
          recipeButton.style.display = "none";
-         return missingIngredients.forEach(ingredient => {
-           return fullRecipeInfo.insertAdjacentHTML("afterbegin", `<li>${this.capitalize(ingredient.name)} ${ingredient.quantity.amount}, ${ingredient.quantity.unit}</li>`)
+         missingIngredients.forEach(ingredient => {
+           fullRecipeInfo.insertAdjacentHTML("afterbegin", `<li>${this.capitalize(ingredient.name)}, ${ingredient.quantity.amount} ${ingredient.quantity.unit}</li>`)
          });
+         fullRecipeInfo.insertAdjacentHTML("afterbegin", "<h2>You need the following ingredients to cook this meal:</h2>");
        },
 
-       // displayTotalCostToCook(missingIngredients, fullRecipeInfo) {
-       //   let recipeCost = missingIngredients.reduce((acc, totalCost) => {
-       //     return acc + totalCost
-       //   }, 0);
-       //   console.log(recipeCost);
-       //   return fullRecipeInfo.insertAdjacentHTML("afterbegin", `<li>This will cost ${recipeCost} to acquire the ingredients needed to make this meal</li>`);
-       // }
+       displayTotalCostToCook(missingIngredients, fullRecipeInfo) {
+         console.log(missingIngredients)
+         let recipeCost = missingIngredients.reduce((acc, ing) => {
+           return acc + ing.cost;
+         }, 0);
+         console.log(recipeCost);
+         fullRecipeInfo.insertAdjacentHTML("beforeend", `<h2>Cost $${(recipeCost * .01).toFixed(2)}</h2>`);
+       },
 
        exitRecipe(fullRecipeInfo) {
         while (fullRecipeInfo.childNodes.length > 2) {

--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -59,13 +59,14 @@ const domUpdates = {
       },
 
     //RECIPE INSTRUCTIONS
-      openRecipeInfo(event, fullRecipeInfo, recipes) {
+      openRecipeInfo(event, fullRecipeInfo, recipes, cookRecipeButton) {
         fullRecipeInfo.style.display = "inline";
         let recipeId = event.path.find(e => e.id).id;
         let recipe = recipes.find(recipe => recipe.id === Number(recipeId));
+        cookRecipeButton.setAttribute("id", recipeId);
+        this.generateInstructions(recipe, fullRecipeInfo);
         this.generateRecipeTitle(recipe, this.generateIngredients(recipe), fullRecipeInfo);
         this.addRecipeImage(recipe);
-        this.generateInstructions(recipe, fullRecipeInfo);
         fullRecipeInfo.insertAdjacentHTML("beforebegin", "<section id='overlay'></div>");
       },
 
@@ -81,7 +82,7 @@ const domUpdates = {
           <h3 id="recipe-title">${recipe.name}</h3>
           <h4>Ingredients</h4>
           <p>${ingredients}</p>`
-        fullRecipeInfo.insertAdjacentHTML("beforeend", recipeTitle);
+        fullRecipeInfo.insertAdjacentHTML("afterbegin", recipeTitle);
       },
 
       addRecipeImage(recipe) {
@@ -96,13 +97,16 @@ const domUpdates = {
         instructions.forEach(i => {
           instructionsList += `<li>${i}</li>`
         });
-        fullRecipeInfo.insertAdjacentHTML("beforeend", "<h4>Instructions</h4>");
-        fullRecipeInfo.insertAdjacentHTML("beforeend", `<ol>${instructionsList}</ol>`);
+        fullRecipeInfo.insertAdjacentHTML("afterbegin", `<ol>${instructionsList}</ol>`);
+        fullRecipeInfo.insertAdjacentHTML("afterbegin", "<h4>Instructions</h4>");
       },
 
+
+
        exitRecipe(fullRecipeInfo) {
-        while (fullRecipeInfo.firstChild &&
-          fullRecipeInfo.removeChild(fullRecipeInfo.firstChild));
+        while (fullRecipeInfo.childNodes.length > 2) {
+          fullRecipeInfo.removeChild(fullRecipeInfo.firstChild);
+        };
         fullRecipeInfo.style.display = "none";
         document.getElementById("overlay").remove();
       },

--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -102,9 +102,6 @@ const domUpdates = {
        },
 
        displayMissingIngredients(missingIngredients, recipeCookButton, fullRecipeInfo, recipeOkayButton) {
-         while (fullRecipeInfo.childNodes.length > 2) {
-           fullRecipeInfo.removeChild(fullRecipeInfo.firstChild);
-         };
          recipeCookButton.style.display = "none";
          missingIngredients.forEach(ingredient => {
            fullRecipeInfo.insertAdjacentHTML("afterbegin", `<li>${this.capitalize(ingredient.name)}, ${ingredient.quantity.amount} ${ingredient.quantity.unit}</li>`)
@@ -117,7 +114,13 @@ const domUpdates = {
          let recipeCost = missingIngredients.reduce((acc, ing) => {
            return acc + ing.cost;
          }, 0);
-         fullRecipeInfo.insertAdjacentHTML("afterbegin", `<h2>Cost $${(recipeCost * .01).toFixed(2)}</h2>.`);
+         fullRecipeInfo.insertAdjacentHTML("afterbegin", `<h2>Cost $${(recipeCost * .01).toFixed(2)}.</h2>`);
+       },
+
+       clearModalView(fullRecipeInfo) {
+         while (fullRecipeInfo.childNodes.length > 3) {
+           fullRecipeInfo.removeChild(fullRecipeInfo.firstChild);
+         };
        },
 
        exitRecipe(fullRecipeInfo) {

--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -65,23 +65,24 @@ const domUpdates = {
         let recipe = recipes.find(recipe => recipe.id === Number(recipeId));
         cookRecipeButton.setAttribute("id", recipeId);
         this.generateInstructions(recipe, fullRecipeInfo);
-        this.generateRecipeTitle(recipe, this.generateIngredients(recipe), fullRecipeInfo);
+        this.generateIngredients(recipe, fullRecipeInfo);
+        this.generateRecipeTitle(recipe, fullRecipeInfo);
         this.addRecipeImage(recipe);
         fullRecipeInfo.insertAdjacentHTML("beforebegin", "<section id='overlay'></div>");
+        cookRecipeButton.style.display = "block";
       },
 
-      generateIngredients(recipe) {
-        return recipe && recipe.ingredients.map(i => {
+      generateIngredients(recipe, fullRecipeInfo) {
+        let ingredients = recipe.ingredients.map(i => {
           return `${this.capitalize(i.name)} (${i.quantity.amount} ${i.quantity.unit})`
         }).join(", ");
+        fullRecipeInfo.insertAdjacentHTML("afterbegin", `<h4>Ingredients</h4> <p>${ingredients}</p>`)
       },
 
-      generateRecipeTitle(recipe, ingredients, fullRecipeInfo) {
+      generateRecipeTitle(recipe, fullRecipeInfo) {
         let recipeTitle = `
           <button id="exit-recipe-btn">X</button>
-          <h3 id="recipe-title">${recipe.name}</h3>
-          <h4>Ingredients</h4>
-          <p>${ingredients}</p>`
+          <h3 id="recipe-title">${recipe.name}</h3>`
         fullRecipeInfo.insertAdjacentHTML("afterbegin", recipeTitle);
       },
 
@@ -118,16 +119,17 @@ const domUpdates = {
        },
 
        clearModalView(fullRecipeInfo) {
-         while (fullRecipeInfo.childNodes.length > 3) {
+         while (fullRecipeInfo.childNodes.length > 4) {
            fullRecipeInfo.removeChild(fullRecipeInfo.firstChild);
          };
        },
 
-       exitRecipe(fullRecipeInfo) {
-        while (fullRecipeInfo.childNodes.length > 2) {
+       exitRecipe(fullRecipeInfo, recipeOkayButton) {
+        while (fullRecipeInfo.childNodes.length > 4) {
           fullRecipeInfo.removeChild(fullRecipeInfo.firstChild);
         };
         fullRecipeInfo.style.display = "none";
+        recipeOkayButton.style.display = "none";
         document.getElementById("overlay").remove();
       },
 

--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -72,7 +72,7 @@ const domUpdates = {
 
       generateIngredients(recipe) {
         return recipe && recipe.ingredients.map(i => {
-          return `${(i.name)} (${i.quantity.amount} ${i.quantity.unit})`
+          return `${this.capitalize(i.name)} (${i.quantity.amount} ${i.quantity.unit})`
         }).join(", ");
       },
 
@@ -106,14 +106,18 @@ const domUpdates = {
            fullRecipeInfo.removeChild(fullRecipeInfo.firstChild);
          };
          recipeButton.style.display = "none";
-         // let completeIngredientsList = missingIngredients.map(i => {
-         //   return `${this.capitalize(i.name)} (${i.quantity.amount} ${i.quantity.unit})`
-         // }).join(", ");
-         // console.log(completeIngredientsList);
          return missingIngredients.forEach(ingredient => {
-           return fullRecipeInfo.insertAdjacentHTML("afterbegin", `<li>${ingredient.name}, ${ingredient.quantity.amount}, ${ingredient.quantity.unit}</li>`)
+           return fullRecipeInfo.insertAdjacentHTML("afterbegin", `<li>${this.capitalize(ingredient.name)} ${ingredient.quantity.amount}, ${ingredient.quantity.unit}</li>`)
          });
        },
+
+       // displayTotalCostToCook(missingIngredients, fullRecipeInfo) {
+       //   let recipeCost = missingIngredients.reduce((acc, totalCost) => {
+       //     return acc + totalCost
+       //   }, 0);
+       //   console.log(recipeCost);
+       //   return fullRecipeInfo.insertAdjacentHTML("afterbegin", `<li>This will cost ${recipeCost} to acquire the ingredients needed to make this meal</li>`);
+       // }
 
        exitRecipe(fullRecipeInfo) {
         while (fullRecipeInfo.childNodes.length > 2) {

--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -101,24 +101,23 @@ const domUpdates = {
         fullRecipeInfo.insertAdjacentHTML("afterbegin", "<h4>Instructions</h4>");
        },
 
-       displayMissingIngredients(missingIngredients, recipeButton, fullRecipeInfo) {
+       displayMissingIngredients(missingIngredients, recipeCookButton, fullRecipeInfo, recipeOkayButton) {
          while (fullRecipeInfo.childNodes.length > 2) {
            fullRecipeInfo.removeChild(fullRecipeInfo.firstChild);
          };
-         recipeButton.style.display = "none";
+         recipeCookButton.style.display = "none";
          missingIngredients.forEach(ingredient => {
            fullRecipeInfo.insertAdjacentHTML("afterbegin", `<li>${this.capitalize(ingredient.name)}, ${ingredient.quantity.amount} ${ingredient.quantity.unit}</li>`)
          });
          fullRecipeInfo.insertAdjacentHTML("afterbegin", "<h2>You need the following ingredients to cook this meal:</h2>");
+         recipeOkayButton.style.display = "block";
        },
 
        displayTotalCostToCook(missingIngredients, fullRecipeInfo) {
-         console.log(missingIngredients)
          let recipeCost = missingIngredients.reduce((acc, ing) => {
            return acc + ing.cost;
          }, 0);
-         console.log(recipeCost);
-         fullRecipeInfo.insertAdjacentHTML("beforeend", `<h2>Cost $${(recipeCost * .01).toFixed(2)}</h2>`);
+         fullRecipeInfo.insertAdjacentHTML("afterbegin", `<h2>Cost $${(recipeCost * .01).toFixed(2)}</h2>.`);
        },
 
        exitRecipe(fullRecipeInfo) {

--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -59,11 +59,12 @@ const domUpdates = {
       },
 
     //RECIPE INSTRUCTIONS
-      openRecipeInfo(event, fullRecipeInfo, recipes, cookRecipeButton) {
+      openRecipeInfo(event, fullRecipeInfo, recipes, cookRecipeButton, recipeOkayButton) {
         fullRecipeInfo.style.display = "inline";
         let recipeId = event.path.find(e => e.id).id;
         let recipe = recipes.find(recipe => recipe.id === Number(recipeId));
         cookRecipeButton.setAttribute("id", recipeId);
+        recipeOkayButton.setAttribute("id", recipeId);
         this.generateInstructions(recipe, fullRecipeInfo);
         this.generateIngredients(recipe, fullRecipeInfo);
         this.generateRecipeTitle(recipe, fullRecipeInfo);
@@ -115,7 +116,7 @@ const domUpdates = {
          let recipeCost = missingIngredients.reduce((acc, ing) => {
            return acc + ing.cost;
          }, 0);
-         fullRecipeInfo.insertAdjacentHTML("afterbegin", `<h2>Cost $${(recipeCost * .01).toFixed(2)}.</h2>`);
+         fullRecipeInfo.insertAdjacentHTML("afterbegin", `<h2>Cost $${(recipeCost * .001).toFixed(2)}.</h2>`);
        },
 
        clearModalView(fullRecipeInfo) {

--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -134,6 +134,7 @@ const domUpdates = {
 
       //PANTRY
        displayPantryInfo(pantry) {
+        document.querySelector(".pantry-list").innerHTML = ''
         pantry.forEach(ingredient => {
           let ingredientHtml = `<li><input type="checkbox" class="pantry-checkbox" id="${ingredient.name}">
             <label for="${ingredient.name}">${ingredient.name}, ${ingredient.count}</label></li>`;

--- a/src/index.html
+++ b/src/index.html
@@ -45,6 +45,7 @@
     <main>
       <div class="recipe-instructions">
         <button class="cook-recipe-button">COOK THIS MEAL!!!</button>
+        <button class="recipe-okay-button">OKAY!</button>
       </div>
       <div class="my-recipes-banner">
         <h1>My Recipes</h1>

--- a/src/index.html
+++ b/src/index.html
@@ -44,6 +44,7 @@
     </aside>
     <main>
       <div class="recipe-instructions">
+        <button class="cook-recipe-button">COOK THIS MEAL!!!</button>
       </div>
       <div class="my-recipes-banner">
         <h1>My Recipes</h1>

--- a/src/pantry.js
+++ b/src/pantry.js
@@ -31,7 +31,9 @@ class Pantry {
     if(missingIngredients.length) {
       return missingIngredients;
     } else {
-      this.removeCookedIngredients(recipe)
+      console.log(this.pantry);
+      this.removeCookedIngredients(recipe);
+      console.log(this.pantry);
     }
   }
 }

--- a/src/pantry.js
+++ b/src/pantry.js
@@ -42,11 +42,10 @@ class Pantry {
   canCook(recipe) {
     let missingIngredients = this.findMissingIngredients(recipe)
     console.log("missing ings", missingIngredients);
-    if(missingIngredients.length) {
-      return missingIngredients;
-    } else {
+    if(!missingIngredients.length) {
       this.removeCookedIngredients(recipe);
     }
+    return missingIngredients;
   }
 }
 

--- a/src/pantry.js
+++ b/src/pantry.js
@@ -41,7 +41,6 @@ class Pantry {
 
   canCook(recipe) {
     let missingIngredients = this.findMissingIngredients(recipe)
-    console.log("missing ings", missingIngredients);
     if(!missingIngredients.length) {
       this.removeCookedIngredients(recipe);
     }

--- a/src/pantry.js
+++ b/src/pantry.js
@@ -3,25 +3,39 @@ class Pantry {
     this.pantry = user.pantry;
   }
 
-  findIngredientById(id) {
-    return this.pantry.find(ingredient => ingredient.id === id)
+  findIngredient(id) {
+    return this.pantry.find(ingredient => ingredient.ingredient === id)
   }
 
   findMissingIngredients(recipe) {
     let missingIngredients = recipe.ingredients.filter(ingredient => {
-      return (!this.findIngredientById(ingredient.id) ||
-      ingredient.quantity.amount > this.findIngredientById(ingredient.id).amount)
+      return (!this.findIngredient(ingredient.id) ||
+      ingredient.quantity.amount > this.findIngredient(ingredient.id).amount)
     })
+    this.removePantryIngredients(missingIngredients);
+    this.calculateRemainingCost(missingIngredients);
+    return missingIngredients;
+  }
+
+  calculateRemainingCost(missingIngredients) {
     missingIngredients.forEach(missingIng => {
       missingIng.cost = Math.floor(missingIng.estimatedCostInCents * missingIng.quantity.amount);
       delete missingIng.estimatedCostInCents;
     })
-    return missingIngredients;
+  }
+
+  removePantryIngredients(missingIngredients) {
+    missingIngredients.forEach(ingredient => {
+      if (this.findIngredient(ingredient.id)) {
+        ingredient.quantity.amount -= this.findIngredient(ingredient.id).amount
+      }
+    });
+    missingIngredients = missingIngredients.filter(ingredient => ingredient.amount > 0)
   }
 
   removeCookedIngredients(recipe) {
     recipe.ingredients.forEach(ingredient => {
-      this.findIngredientById(ingredient.id).amount -= ingredient.quantity.amount
+      this.findIngredient(ingredient.id).amount -= ingredient.quantity.amount
     })
   }
 
@@ -31,9 +45,7 @@ class Pantry {
     if(missingIngredients.length) {
       return missingIngredients;
     } else {
-      console.log(this.pantry);
       this.removeCookedIngredients(recipe);
-      console.log(this.pantry);
     }
   }
 }

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -146,10 +146,15 @@ function cookRecipe() {
   let recipe = recipes.find(recipe => recipe.id === Number(recipeId));
   let missingIngredients = user.pantry.canCook(recipe)
   if (missingIngredients.length) {
-
+    domUpdates.displayMissingIngredients(missingIngredients, cookRecipeButton, fullRecipeInfo);
+    // hide cook meal button, replace it with okay button
+    // okay button should have attribute of id set to recipe id
+    // replace HTML in modal view with list of ingredients needed and total cost for those ingredients
+    // ok button should revert back to modal view of recipe instructions etc.
   } else {
     findPantryInfo();
     domUpdates.displayPantryInfo(pantryInfo.sort((a, b) => a.name.localeCompare(b.name)));
+    user.addRecipe("recipesToCook", recipeId);
     // update user pantry in api with a fetch post network fetchRequests
     //
   }

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -27,6 +27,7 @@ const searchInput = document.querySelector("#search-input");
 const showPantryRecipes = document.querySelector(".show-pantry-recipes-btn");
 const tagList = document.querySelector(".tag-list");
 const tagFilterDropdown = document.querySelector(".filter-dropbtn");
+const cookRecipeButton = document.querySelector(".cook-recipe-button");
 
 let pantryInfo = [];
 let viewFavorites = false;
@@ -47,7 +48,8 @@ savedRecipesBtn.addEventListener("click", showSavedRecipes);
 searchBtn.addEventListener("click", pressEnterSearch);
 showPantryRecipes.addEventListener("click", findCheckedPantryBoxes);
 searchForm.addEventListener("submit", pressEnterSearch);
-tagFilterDropdown.addEventListener("click", toggleFilter)
+tagFilterDropdown.addEventListener("click", toggleFilter);
+cookRecipeButton.addEventListener("click", cookRecipe);
 
 function loadAllData() {
   Promise.all([fetchRequests.getUsers(), fetchRequests.getRecipes(), fetchRequests.getIngredients()])
@@ -138,6 +140,13 @@ function showAllRecipes() {
 
 
 // FAVORITE RECIPE FUNCTIONALITY
+function cookRecipe() {
+  // invoke user.pantry.canCook function
+  //
+}
+
+
+
 function addToMyRecipes() {
   if (event.target.className === "card-apple-icon") {
     let cardId = parseInt(event.target.closest(".recipe-card").id);
@@ -151,7 +160,7 @@ function addToMyRecipes() {
   } else if (event.target.id === "exit-recipe-btn") {
     domUpdates.exitRecipe(fullRecipeInfo);
   } else if (isDescendant(event.target.closest(".recipe-card"), event.target)) {
-    domUpdates.openRecipeInfo(event, fullRecipeInfo, recipes);
+    domUpdates.openRecipeInfo(event, fullRecipeInfo, recipes, cookRecipeButton);
   }
 }
 

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -142,7 +142,6 @@ function showAllRecipes() {
 
 // FAVORITE RECIPE FUNCTIONALITY
 function cookRecipe() {
-  // let recipeId = event.path.find(e => e.id).id;
   let recipeId = event.target.id;
   let recipe = recipes.find(recipe => recipe.id === Number(recipeId));
   let missingIngredients = user.pantry.canCook(recipe)
@@ -150,24 +149,13 @@ function cookRecipe() {
     domUpdates.clearModalView(fullRecipeInfo);
     domUpdates.displayTotalCostToCook(missingIngredients, fullRecipeInfo);
     domUpdates.displayMissingIngredients(missingIngredients, cookRecipeButton, fullRecipeInfo, recipeOkayButton);
-
-    // recipeOkayButton.style.visibilty("visible");
-    // hide cook meal button, replace it with okay button
-    // okay button should have attribute of id set to recipe id
-    // replace HTML in modal view with list of ingredients needed and total cost for those ingredients
-    // ok button should revert back to modal view of recipe instructions etc.
+    domUpdates.generateRecipeTitle(recipe, fullRecipeInfo);
+    domUpdates.addRecipeImage(recipe);
   } else {
     findPantryInfo();
     domUpdates.displayPantryInfo(pantryInfo.sort((a, b) => a.name.localeCompare(b.name)));
     user.addRecipe("recipesToCook", recipeId);
-    // update user pantry in api with a fetch post network fetchRequests
-    //
   }
-
-  // if yes run scripts to display ingredients needed, cost, etc.
-  // else update
-  //
-  //
 }
 
 
@@ -183,7 +171,7 @@ function addToMyRecipes() {
       user.removeRecipe('favoriteRecipes', cardId);
     }
   } else if (event.target.id === "exit-recipe-btn") {
-    domUpdates.exitRecipe(fullRecipeInfo);
+    domUpdates.exitRecipe(fullRecipeInfo, recipeOkayButton);
   } else if (isDescendant(event.target.closest(".recipe-card"), event.target)) {
     domUpdates.openRecipeInfo(event, fullRecipeInfo, recipes, cookRecipeButton);
   }

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -141,8 +141,10 @@ function showAllRecipes() {
 
 // FAVORITE RECIPE FUNCTIONALITY
 function cookRecipe() {
-  // invoke user.pantry.canCook function
-  //
+  // let recipeId = event.path.find(e => e.id).id;
+  let recipeId = event.target.id;
+  let recipe = recipes.find(recipe => recipe.id === Number(recipeId));
+  user.pantry.canCook(recipe)
 }
 
 

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -53,9 +53,10 @@ function loadAllData() {
   Promise.all([fetchRequests.getUsers(), fetchRequests.getRecipes(), fetchRequests.getIngredients()])
   .then(values => {
     user = generateUser(values[0]);
+    user.pantry = generateUserPantry(user);
     domUpdates.loadUserDom(user);
-    ingredients = values[2];
-    recipes = instantiateRecipes(values[1]);
+    ingredients = generateIngredients(values[2]);
+    recipes = generateRecipes(values[1]);
     findPantryInfo();
     domUpdates.displayPantryInfo(pantryInfo.sort((a, b) => a.name.localeCompare(b.name)));
     createCards();
@@ -68,8 +69,16 @@ function generateUser(users) {
   return new User(users[Math.floor(Math.random() * users.length)]);
 }
 
-function instantiateRecipes(recipes) {
+function generateRecipes(recipes) {
   return recipes.map(recipe => new Recipe(recipe, ingredients));
+}
+
+function generateUserPantry(user) {
+  return new Pantry(user);
+}
+
+function generateIngredients(ingredients) {
+  return ingredients.map(ingredient => new Ingredient(ingredient))
 }
 
 //CALL domUpdates
@@ -208,7 +217,7 @@ function filterRecipes(recipeArray) {
 
 // CREATE AND USE PANTRY
 function findPantryInfo() {
-  user.pantry.forEach(item => {
+  user.pantry.pantry.forEach(item => {
     let itemInfo = ingredients.find(ingredient => {
       return ingredient.id === item.ingredient;
     });

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -4,6 +4,8 @@ import domUpdates from './domUpdates';
 
 import User from './user';
 import Recipe from './recipe';
+import Pantry from './pantry';
+import Ingredient from './ingredient';
 import './images/apple-logo-outline.png';
 import './images/apple-logo.png';
 import './images/search.png';

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -28,6 +28,7 @@ const showPantryRecipes = document.querySelector(".show-pantry-recipes-btn");
 const tagList = document.querySelector(".tag-list");
 const tagFilterDropdown = document.querySelector(".filter-dropbtn");
 const cookRecipeButton = document.querySelector(".cook-recipe-button");
+const recipeOkayButton = document.querySelector(".recipe-okay-button");
 
 let pantryInfo = [];
 let viewFavorites = false;
@@ -146,8 +147,9 @@ function cookRecipe() {
   let recipe = recipes.find(recipe => recipe.id === Number(recipeId));
   let missingIngredients = user.pantry.canCook(recipe)
   if (missingIngredients.length) {
-    domUpdates.displayMissingIngredients(missingIngredients, cookRecipeButton, fullRecipeInfo);
-    domUpdates.displayTotalCostToCook(missingIngredients, fullRecipeInfo)
+    domUpdates.displayMissingIngredients(missingIngredients, cookRecipeButton, fullRecipeInfo, recipeOkayButton);
+    domUpdates.displayTotalCostToCook(missingIngredients, fullRecipeInfo);
+    // recipeOkayButton.style.visibilty("visible");
     // hide cook meal button, replace it with okay button
     // okay button should have attribute of id set to recipe id
     // replace HTML in modal view with list of ingredients needed and total cost for those ingredients

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -144,7 +144,20 @@ function cookRecipe() {
   // let recipeId = event.path.find(e => e.id).id;
   let recipeId = event.target.id;
   let recipe = recipes.find(recipe => recipe.id === Number(recipeId));
-  user.pantry.canCook(recipe)
+  let missingIngredients = user.pantry.canCook(recipe)
+  if (missingIngredients.length) {
+
+  } else {
+    findPantryInfo();
+    domUpdates.displayPantryInfo(pantryInfo.sort((a, b) => a.name.localeCompare(b.name)));
+    // update user pantry in api with a fetch post network fetchRequests
+    //
+  }
+
+  // if yes run scripts to display ingredients needed, cost, etc.
+  // else update
+  //
+  //
 }
 
 

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -147,8 +147,10 @@ function cookRecipe() {
   let recipe = recipes.find(recipe => recipe.id === Number(recipeId));
   let missingIngredients = user.pantry.canCook(recipe)
   if (missingIngredients.length) {
-    domUpdates.displayMissingIngredients(missingIngredients, cookRecipeButton, fullRecipeInfo, recipeOkayButton);
+    domUpdates.clearModalView(fullRecipeInfo);
     domUpdates.displayTotalCostToCook(missingIngredients, fullRecipeInfo);
+    domUpdates.displayMissingIngredients(missingIngredients, cookRecipeButton, fullRecipeInfo, recipeOkayButton);
+
     // recipeOkayButton.style.visibilty("visible");
     // hide cook meal button, replace it with okay button
     // okay button should have attribute of id set to recipe id

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -51,6 +51,7 @@ showPantryRecipes.addEventListener("click", findCheckedPantryBoxes);
 searchForm.addEventListener("submit", pressEnterSearch);
 tagFilterDropdown.addEventListener("click", toggleFilter);
 cookRecipeButton.addEventListener("click", cookRecipe);
+recipeOkayButton.addEventListener("click", returnToRecipeView);
 
 function loadAllData() {
   Promise.all([fetchRequests.getUsers(), fetchRequests.getRecipes(), fetchRequests.getIngredients()])
@@ -158,7 +159,12 @@ function cookRecipe() {
   }
 }
 
-
+function returnToRecipeView() {
+  domUpdates.clearModalView(fullRecipeInfo);
+  domUpdates.openRecipeInfo(event, fullRecipeInfo, recipes, cookRecipeButton, recipeOkayButton);
+  recipeOkayButton.style.display = "none";
+  document.getElementById("overlay").remove();
+}
 
 function addToMyRecipes() {
   if (event.target.className === "card-apple-icon") {
@@ -173,7 +179,7 @@ function addToMyRecipes() {
   } else if (event.target.id === "exit-recipe-btn") {
     domUpdates.exitRecipe(fullRecipeInfo, recipeOkayButton);
   } else if (isDescendant(event.target.closest(".recipe-card"), event.target)) {
-    domUpdates.openRecipeInfo(event, fullRecipeInfo, recipes, cookRecipeButton);
+    domUpdates.openRecipeInfo(event, fullRecipeInfo, recipes, cookRecipeButton, recipeOkayButton);
   }
 }
 

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -147,6 +147,7 @@ function cookRecipe() {
   let missingIngredients = user.pantry.canCook(recipe)
   if (missingIngredients.length) {
     domUpdates.displayMissingIngredients(missingIngredients, cookRecipeButton, fullRecipeInfo);
+    domUpdates.displayTotalCostToCook(missingIngredients, fullRecipeInfo)
     // hide cook meal button, replace it with okay button
     // okay button should have attribute of id set to recipe id
     // replace HTML in modal view with list of ingredients needed and total cost for those ingredients

--- a/test/test-data.js
+++ b/test/test-data.js
@@ -2,13 +2,13 @@ const users = [
   {id: 1,
   name: "Saige O'Kon",
   pantry: [
-  {id: 1,
+  {ingredient: 1,
   amount: 2},
 
-  {id: 2,
+  {ingredient: 2,
   amount: 5},
 
-  {id: 3,
+  {ingredient: 3,
   amount: 3}],
   favoriteRecipes: [],
   recipesToCook: []


### PR DESCRIPTION
## Pull Request

<br>

### Description

* Is this a feature or a fix?
This is a feature

* Where should the reviewer start?
CD into what's cookin', run npm start and navigate to the appropriatwe localhost site.

* What functionalities do these changes effect? Why were these changes made? What was the motivation behind these changes?
This pull request does the following:
1. Adds a "Cook Meal" button that allows a user to determine whether a meal can be cooked or not. If it can, it is added to the appropriate array (not yet displayed in the dom) and the ingredients are removed from the user pantry, as reflected in both the dom and data model. 
2. If a user does NOT have enough ingredients to cook a meal, the ingredients needed are displayed in the modal view indicating the name of each ingredient needed as well as the quantity and measurement for each ingredient needed.

* What outside features or research did you use to implement this fix?

* How should this be tested?
Open the dev tools on the page, and try out the Cook Meal button on different recipes and look for the modal view to change if it cannot be cooked. If the pantry drop down menu is open, and you click Cook Meal on a meal that can actually be cooked, you will see the ingredients quantities change in the user pantry.
* Applicable screenshot(s): 

<br>

***

#### Please review considerations below:

- [ ] Follows Turing Style Guidelines
- [ ] Changes generate no new warnings or errors(linter etc)
- [ ] Checked code for and corrected any spelling errors
- [ ] README has been updated(if applicable)
