### PR TITLE
Create functionality to update users pantry ingredients in the api when a meal is cooked.

### DIFF
--- a/src/fetchRequests.js
+++ b/src/fetchRequests.js
@@ -12,6 +12,23 @@ const fetchRequests = {
   getRecipes() {
     return fetch("http://localhost:3001/api/v1/recipes")
     .then(response => response.json());
+  },
+
+  postIngredient(user, ingredient) {
+    fetch("http://localhost:3001/api/v1/users", {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        "userID": user.id,
+        "ingredientID": ingredient.ingredient,
+        "ingredientModification": ingredient.modification
+      }),
+    })
+    .then(response => response.json())
+    .then(data => console.log(data))
+    .catch(err => console.log(error));
   }
 };
 

--- a/src/pantry.js
+++ b/src/pantry.js
@@ -1,5 +1,5 @@
 class Pantry {
-  constructor(user) {
+  constructor(user, recipe) {
     this.pantry = user.pantry;
   }
 
@@ -35,7 +35,8 @@ class Pantry {
 
   removeCookedIngredients(recipe) {
     recipe.ingredients.forEach(ingredient => {
-      this.findIngredient(ingredient.id).amount -= ingredient.quantity.amount
+      this.findIngredient(ingredient.id).amount -= ingredient.quantity.amount;
+      this.findIngredient(ingredient.id).modification = (0 - ingredient.quantity.amount);
     })
   }
 

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -177,8 +177,17 @@ function cookRecipe() {
   } else {
     domUpdates.displayPantryInfo(generatePantryInfo());
     user.addRecipe("recipesToCook", recipeId);
+    updateUserPantryAPI(user, recipe);
   }
 }
+
+function updateUserPantryAPI(user, recipe) {
+  user.pantry.pantry.forEach(ingredient => {
+    if (ingredient.modification) {
+      fetchRequests.postIngredient(user, ingredient)
+    }
+  })
+  }
 
 function returnToRecipeView() {
   domUpdates.clearModalView(fullRecipeInfo);

--- a/test/pantry-test.js
+++ b/test/pantry-test.js
@@ -19,7 +19,7 @@ describe('Pantry', () => {
     ingredients = ingredientsData.map(data => new Ingredient(data));
     userInfo = users[0];
     user = new User(userInfo);
-    pantry = new Pantry(user);
+    pantry = new Pantry(user, recipeData[1]);
     recipes = recipeData.map(recipe => new Recipe(recipe, ingredients));
   });
 
@@ -31,14 +31,14 @@ describe('Pantry', () => {
     expect(pantry.pantry).to.eql(user.pantry);
   });
 
-  it('pantry should be able to indicate if a user can cook a given meal', () => {
+  it.only('pantry should be able to indicate if a user can cook a given meal', () => {
     pantry.canCook(recipeData[1]);
     expect(pantry.pantry).to.eql(
     {id: 2,
     amount: 4})
   });
 
-  it.only(`if there are not enough ingredients, pantry should return array of ingredients needed to cook a meal`, () => {
+  it(`if there are not enough ingredients, pantry should return array of ingredients needed to cook a meal`, () => {
     expect(pantry.canCook(recipes[0])).to.eql([
   {
     id: 5,


### PR DESCRIPTION
## Pull Request

<br>

### Description

* Is this a feature or a fix?
This is a feature, updating the user's ingredients in the api when a meal can be cooked. 

* Where should the reviewer start?
Open whats-cookin project in atom/vsCode. CD into whats-cookin and run npm start to initialize the server. Navigate to the site. CD into whats-cookin-api, run npm start to initialize the server. 

* What functionalities do these changes effect? Why were these changes made? What was the motivation behind these changes?
This updates the api so data is current when a user decided to cook a meal. The user pantry is not only updated locally.
Changes were made to the removeIngredients method in pantry. A function (postIngredient) was added to fetcheRequests.js. Another function was added to scripts.js (updateUserPantryAPI).

* What outside features or research did you use to implement this fix?

* How should this be tested?
Not applicable, fetch requests not required to be tested for this project.

* Applicable screenshot(s): 

<br>

***

#### Please review considerations below:

- [ ] Follows Turing Style Guidelines
- [ ] Changes generate no new warnings or errors(linter etc)
- [ ] Checked code for and corrected any spelling errors
- [ ] README has been updated(if applicable)
